### PR TITLE
Fullscreen option when entering Zen mode

### DIFF
--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -90,6 +90,17 @@ export class SettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Trigger fullscreen")
+			.setDesc("Whether entering/exiting Zen should cause Obsidian to enter/exit fullscreen mode.")
+			.addToggle(tc => tc
+				.setValue(this.plugin.settings.preferences.fullScreen)
+				.onChange(async (value) => {
+					this.plugin.settings.preferences.fullScreen = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
 			.setHeading()
 			.setName("Integrations")
 			.setDesc(createFragment((el) => {

--- a/src/ui/ZenView.ts
+++ b/src/ui/ZenView.ts
@@ -48,6 +48,10 @@ export class ZenView extends View {
 
 	async toggleZen() {
 		this.plugin.settings.enabled = !this.plugin.settings.enabled;
+		if (this.plugin.settings.preferences.fullScreen) {
+			this.plugin.settings.enabled ? this.containerEl.doc.body.requestFullscreen() : this.containerEl.doc.exitFullscreen();
+		}
+
 		await this.plugin.saveSettings();
 		await this.updateClass();
 	}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,7 +12,8 @@ export interface ZenPreferences{
 	statusBar: boolean,
 	fileHeader: boolean,
 	sideDockLeft: boolean,
-	sideDockRight: boolean
+	sideDockRight: boolean,
+	fullScreen: boolean
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -24,6 +25,7 @@ export const DEFAULT_SETTINGS: Settings = {
 		fileHeader: false,
 		sideDockLeft: true,
 		sideDockRight: true,
+		fullScreen: false
 	},
 	integrations: []
 }


### PR DESCRIPTION
Adds a new setting to automatically enter/exit fullscreen when Zen is toggled.

Closes #7.