### PR TITLE
Only show header icon on mouse move

### DIFF
--- a/src/ui/ZenView.ts
+++ b/src/ui/ZenView.ts
@@ -76,11 +76,23 @@ export class ZenView extends View {
 		headerIcon.appendChild(headerInner);
 		this.headerIcon = headerIcon;
 
+		let timer: ReturnType<typeof setTimeout>;
+		this.containerEl.doc.onmousemove = () => {
+			if (!this.plugin.settings.enabled) return;
+			if (!this.plugin.settings.preferences.sideDockLeft) return;
+
+			this.headerIcon.style.display = 'flex';
+			clearTimeout(timer);
+			timer = setTimeout(() => {
+				this.headerIcon.style.display = 'none';
+			}, 1000);
+		};
+
 		// @ts-ignore
 		this.app.workspace.leftSplit.getContainer().containerEl.appendChild(headerIcon);
 	}
 
-	addBodyClasses(addBaseClass ?: boolean): void {
+	addBodyClasses(addBaseClass?: boolean): void {
 		if (addBaseClass) {
 			this.containerEl.doc.body.addClass("zen-enabled");
 		}
@@ -91,7 +103,7 @@ export class ZenView extends View {
 		})
 	}
 
-	removeBodyClasses(removeBaseClass ?: boolean): void {
+	removeBodyClasses(removeBaseClass?: boolean): void {
 		if (removeBaseClass) {
 			this.containerEl.doc.body.removeClass("zen-enabled");
 		}

--- a/styles.css
+++ b/styles.css
@@ -28,10 +28,6 @@ https://github.com/Maxymillion/zen
 	opacity: 0.8;
 }
 
-.zen-enabled.zen-module--sideDockLeft .zen-header {
-	display: flex;
-}
-
 .zen-header-inner svg {
 	--icon-size: var(--icon-l);
 	--icon-stroke: var(--icon-l-stroke-width);


### PR DESCRIPTION
Although it's a small thing, I find the eye icon a little distracting when everything else is hidden by Zen mode.

These changes hide the icon when the mouse is not being moved (i.e. when one is simply typing).